### PR TITLE
Support python < 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd monstr
 python3 -m venv venv
 source venv/bin/activate
 pip install .
-# probably required to run examples else nostr module won't be found
+# probably required to run examples else monstr module won't be found
 export PYTHONPATH="$PYTHONPATH:./"
 ```
 to use postgres as store psycopg2 must be installed

--- a/examples/view_profile.py
+++ b/examples/view_profile.py
@@ -53,7 +53,7 @@ class MetaServer:
 
         k = Keys.get_key(pub_k)
         if k is None:
-            raise ServerError(f'{pub_k} - doesn\'t look like a nonstr key')
+            raise ServerError(f'{pub_k} - doesn\'t look like a nostr key')
 
         pub_k = k.public_key_hex()
         ret = {

--- a/src/monstr/client/client.py
+++ b/src/monstr/client/client.py
@@ -7,7 +7,6 @@
 from __future__ import annotations
 
 import copy
-# from typing import Callable
 import logging
 import aiohttp
 try:
@@ -16,7 +15,7 @@ except:
     pass
 import asyncio
 import json
-from typing import Callable
+from typing import Callable, Union
 from json import JSONDecodeError
 from datetime import datetime
 from monstr.util import util_funcs
@@ -366,7 +365,7 @@ class Client:
                 ])
             )
 
-    async def auth(self, signer: SignerInterface | Keys, challenge: str):
+    async def auth(self, signer: Union[SignerInterface, Keys], challenge: str):
         # better to use signer but if we just got keys we'll turn into a BasicKeySigner
         if isinstance(signer, Keys):
             signer = BasicKeySigner(signer)
@@ -453,7 +452,7 @@ class Client:
         return ret
 
     async def query_until(self,
-                          until_date: datetime | int,
+                          until_date: Union[datetime, int],
                           filters: object = None,
                           do_event: callable = None,
                           timeout=None,
@@ -745,7 +744,7 @@ class ClientPool:
     """
 
     def __init__(self,
-                 clients: str | Client | list[str | Client],
+                 clients: Union[str, Client, list[Union[str, Client]]],
                  on_connect: Callable = None,
                  on_status: Callable = None,
                  on_eose: Callable = None,
@@ -1144,7 +1143,7 @@ class ClientPool:
                            on_complete=on_complete)
 
     def query_until(self,
-                    until_date: datetime | int,
+                    until_date: Union[datetime, int],
                     filters: [] = None,
                     do_event: callable = None,
                     wait_connect: bool = False,

--- a/src/monstr/encrypt.py
+++ b/src/monstr/encrypt.py
@@ -18,7 +18,7 @@ import secp256k1
 import bech32
 from enum import Enum
 
-import typing
+from typing import Union
 
 # required for encrypt_event, decrypt event... maybe these methods don't really belong here
 # or else keys should be in onw file/folder for encrypt?
@@ -261,7 +261,7 @@ class Encrypter(ABC):
         ret.tags = [['p', to_k_hex]]
         return ret
 
-    def encrypt_event(self, evt: Event, to_pub_k: str | Keys) -> Event:
+    def encrypt_event(self, evt: Event, to_pub_k: Union[str, Keys]) -> Event:
         ret = self._make_encrypt_event(evt, to_pub_k)
         # the pub_k author must be us
         ret.pub_key = self.public_key_hex()
@@ -270,7 +270,7 @@ class Encrypter(ABC):
                                    to_pub_k=ret.tags.get_tag_value_pos('p'))
         return ret
 
-    async def aencrypt_event(self, evt: Event, to_pub_k: str | Keys) -> Event:
+    async def aencrypt_event(self, evt: Event, to_pub_k: Union[str, Keys]) -> Event:
         ret = self._make_encrypt_event(evt, to_pub_k)
         # the pub_k author must be us
         ret.pub_key = await self.apublic_key_hex()
@@ -304,7 +304,7 @@ class Encrypter(ABC):
 
 class KeyEncrypter(Encrypter):
 
-    def __init__(self, key: Keys | str):
+    def __init__(self, key: Union[Keys, str]):
         if isinstance(key, str):
             key = Keys(priv_k=key)
         if key.private_key_hex() is None:
@@ -319,7 +319,7 @@ class KeyEncrypter(Encrypter):
 
 class NIP4Encrypt(KeyEncrypter):
 
-    def __init__(self, key: Keys | str):
+    def __init__(self, key: Union[Keys, str]):
         super().__init__(key)
 
         self._ec_key = ec.derive_private_key(int.from_bytes(self._priv_k.private_key,
@@ -401,7 +401,7 @@ class NIP44Encrypt(KeyEncrypter):
     V2_HASH = sha256
     V2_SALT = b'nip44-v2'
 
-    def __init__(self, key: Keys | str):
+    def __init__(self, key: Union[Keys, str]):
         super().__init__(key)
 
     # hkdf functions taken and modified from https://en.wikipedia.org/wiki/HKDF 14/4/2024

--- a/src/monstr/encrypt.py
+++ b/src/monstr/encrypt.py
@@ -66,7 +66,7 @@ class Keys:
     @staticmethod
     def is_hex_key(key:str):
         """
-            returns true if looks like valid hex string for nonstr key its not possible to tell if priv/pub
+            returns true if looks like valid hex string for nostr key its not possible to tell if priv/pub
         """
         ret = False
         if len(key) == 64:
@@ -176,7 +176,7 @@ class Keys:
         else:
             self._pub_k = Keys.hex_key(pub_k)
             if not self._pub_k:
-                raise Exception('pub_k does\'t look like a valid nonstr key - %s' % pub_k)
+                raise Exception('pub_k does\'t look like a valid nostr key - %s' % pub_k)
 
     def private_key_hex(self):
         return self._priv_k

--- a/src/monstr/event/event.py
+++ b/src/monstr/event/event.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Union
 import json
 import logging
 from json import JSONDecodeError
@@ -162,7 +163,7 @@ class Event:
     #     )
 
     @staticmethod
-    def load(event_data: str | dict, validate=False) -> 'Event':
+    def load(event_data: Union[str, dict], validate=False) -> 'Event':
         """
             return a Event object either from a dict or json str this replaces the old from_JSON method
             that was actually just from a string...

--- a/src/monstr/giftwrap.py
+++ b/src/monstr/giftwrap.py
@@ -1,5 +1,6 @@
 import json
 import random
+from typing import Union
 from datetime import datetime
 from monstr.signing.signing import SignerInterface, BasicKeySigner
 from monstr.encrypt import Keys
@@ -45,7 +46,7 @@ class GiftWrap:
 
     async def _make_seal(self,
                          rumour_evt: Event,
-                         to_pub_k: Keys | str) -> Event:
+                         to_pub_k: Union[Keys, str]) -> Event:
 
         if rumour_evt.sig:
             raise GiftWrapException('GiftWrap::_make_seal: rumour event should not be signed!')
@@ -63,7 +64,7 @@ class GiftWrap:
         await self._signer.sign_event(ret)
         return ret
 
-    async def wrap(self, evt: Event, to_pub_k: Keys | str, pow: int = None) -> tuple[Event, Keys]:
+    async def wrap(self, evt: Event, to_pub_k: Union[Keys, str], pow: int = None) -> tuple[Event, Keys]:
         if isinstance(to_pub_k, Keys):
             to_pub_k = to_pub_k.public_key_hex()
 

--- a/src/monstr/ident/event_handlers.py
+++ b/src/monstr/ident/event_handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 if TYPE_CHECKING:
     from monstr.client.client import Client
 
@@ -42,7 +42,7 @@ class ProfileEventHandlerInterface(ABC):
         pass
 
     @abstractmethod
-    async def aload_contacts(self, p: str | Profile) -> ContactList:
+    async def aload_contacts(self, p: Union[str, Profile]) -> ContactList:
         pass
 
     @staticmethod
@@ -289,7 +289,7 @@ class NetworkedProfileEventHandler(ProfileEventHandler):
                         self._cache[k] = n_p
         return ProfileList(ret)
 
-    async def aload_contacts(self, p: str | Profile) -> ContactList:
+    async def aload_contacts(self, p: Union[str, Profile]) -> ContactList:
         if isinstance(p, Profile):
             pub_key = p.public_key
         else:

--- a/src/monstr/inbox.py
+++ b/src/monstr/inbox.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from typing import Union
 from monstr.encrypt import Keys
 from monstr.signing.signing import SignerInterface
 from monstr.event.event import Event
@@ -48,7 +49,7 @@ class Inbox:
         # decrypted
         self._share_maps = {}
 
-    async def set_share_map(self, for_sign: SignerInterface, to_keys: [Keys | str]):
+    async def set_share_map(self, for_sign: SignerInterface, to_keys: list[Union[Keys, str]]):
         n_map = {}
         for k in to_keys:
             if isinstance(k, Keys):
@@ -75,7 +76,7 @@ class Inbox:
     def kind(self) -> int:
         return self._kind
 
-    async def wrap_event(self, evt, from_sign: SignerInterface = None, to_k: Keys | str = None) -> Event:
+    async def wrap_event(self, evt, from_sign: SignerInterface = None, to_k: Union[Keys, str] = None) -> Event:
         tags = []
         if to_k and isinstance(to_k, Keys):
             to_k = to_k.public_key_hex()

--- a/src/monstr/relay/accept_handlers.py
+++ b/src/monstr/relay/accept_handlers.py
@@ -1,4 +1,5 @@
 import json
+from typing import Union
 from abc import ABC, abstractmethod
 from datetime import datetime
 from aiohttp import http_websocket
@@ -154,7 +155,7 @@ class AuthenticatedAcceptor(AcceptReqHandler, NIPSupport):
         ever get authenticated
     """
     def __init__(self,
-                 authorised_keys: set | list | None = None,
+                 authorised_keys: Union[set, list, None] = None,
                  descriptive_msg=True):
 
         # hex pubkeys to accept - probably we should also accept [Keys] maybe even Profiles?
@@ -171,7 +172,7 @@ class AuthenticatedAcceptor(AcceptReqHandler, NIPSupport):
         return self._authorised_keys
 
     @authorised_keys.setter
-    def authorised_keys(self, authorised_keys: list | set | None = None):
+    def authorised_keys(self, authorised_keys: Union[list, set, None] = None):
         if isinstance(authorised_keys, list):
             authorised_keys = set(authorised_keys)
         self._authorised_keys = authorised_keys

--- a/src/monstr/relay/relay.py
+++ b/src/monstr/relay/relay.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 if TYPE_CHECKING:
     pass
 import logging
@@ -76,7 +76,7 @@ class Relay:
     VALID_CMDS = ['EVENT', 'REQ', 'CLOSE', 'AUTH']
 
     def __init__(self,
-                 store: RelayEventStoreInterface | ARelayEventStoreInterface = None,
+                 store: Union[RelayEventStoreInterface, ARelayEventStoreInterface] = None,
                  accept_req_handler:[AcceptReqHandler] = None,
                  sub_filter: [SubscriptionFilter] = None,
                  max_sub=10,


### PR DESCRIPTION
I use your python module both for my nsite project and a git remote helper. (https://github.com/lez/nsite and https://github.com/lez/git-remote-nostr) I'm very gateful that monstr exists. It's the only async python nostr module that I found.
So I'd like my users to be able to use the tools I develop on slightly outdated computers (and... on my server).
For this reason I reverted the `|`'s to `Union[...]` because it gave me `SyntaxError`s on older python versions.

On top, there are a few typos fixed.